### PR TITLE
Filter out best blast result from blastx runs against Uniprot

### DIFF
--- a/seq2ids/parts_best_match.py
+++ b/seq2ids/parts_best_match.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+# read in spreadsheet which we need to trim to one blast hit
+# per seq_name
+df = pd.read_csv("target/part_characterization.tsv", header=0, sep="\t")
+
+# remove whole duplicates from original tsv
+df = df[df.nunique(1) > 1]
+
+# sort the rows for each seq_name based on bitscore column
+df = df.groupby("seq_name", as_index=False).apply(
+    lambda x: x.sort_values("bitscore", ascending=False)
+)
+
+# select only the first two rows from each of the sorted groups
+df = df.groupby("seq_name", as_index=False).apply(lambda x: x.head(2))
+
+# applying groupby() multiple times results in a multi index
+# being created which needs to be removed
+df = df.reset_index()
+df = df[df.columns.drop(list(df.filter(regex="level_")))]
+
+# count number of filled columns for all bitscore filtered groups
+df["count"] = df.notnull().sum(axis=1)
+
+# pick seq_name row with highest count value
+# i.e., the row which is richest in metadata
+df = df.loc[df.reset_index().groupby(["seq_name"])["count"].idxmax()]
+
+# drop the count column since it does not add any value to the
+# data itself
+df = df.drop(columns="count")
+
+# write bitscore and presence of metadata filtered part_characterization.tsv
+# file into another tsv file in target folder
+df.to_csv("target/filtered_part_characterization.tsv", sep="\t")


### PR DESCRIPTION
This PR seeks to address issue #8.

The script does three things:
* Removes all whole duplicates
* Applies the bitscore filter
* Applies the presence of metadata filter, as a first pass

From our last discussion, it was decided that the bitscore filter wasn't more important than the metadata filter. Some pain points to be addressed:

- [ ] Allow a threshold value in the bitscore column that will help prioritize between the above two columns
- [ ] Subset the metadata columns. Right now I'm just counting all the columns in a seq_name row